### PR TITLE
Fix setting string descriptor values on OS X

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -156,5 +156,8 @@ func generateDescAttributes(d *Descriptor, h uint16) attr {
 		props: d.props,
 		pvt:   d,
 	}
+	if len(d.valuestr) > 0 {
+		a.value = []byte(d.valuestr)
+	}
 	return a
 }

--- a/common.go
+++ b/common.go
@@ -315,8 +315,9 @@ type Descriptor struct {
 	props  Property // enabled properties
 	secure Property // security enabled properties
 
-	h     uint16
-	value []byte
+	h        uint16
+	value    []byte
+	valuestr string
 
 	rhandler ReadHandler
 	whandler WriteHandler
@@ -365,6 +366,18 @@ func (d *Descriptor) SetValue(b []byte) {
 	// d.secure |= CharRead
 	d.value = make([]byte, len(b))
 	copy(d.value, b)
+}
+
+// SetStringValue makes the descriptor support read requests, and returns a static value.
+// SetStringValue must be called before the containing service is added to a server.
+// SetStringValue panics if the descriptor has already configured with a ReadHandler.
+func (d *Descriptor) SetStringValue(s string) {
+	if d.rhandler != nil {
+		panic("descriptor has been configured with a read handler")
+	}
+	d.props |= CharRead
+	// d.secure |= CharRead
+	d.valuestr = s
 }
 
 // HandleRead makes the descriptor support read requests, and routes read requests to h.

--- a/device_darwin.go
+++ b/device_darwin.go
@@ -226,8 +226,14 @@ func (d *device) AddService(s *Service) error {
 				// skip CCCD
 				continue
 			}
+			var v interface{}
+			if len(d.valuestr) > 0 {
+				v = d.valuestr
+			} else {
+				v = d.value
+			}
 			xd := xpc.Dict{
-				"kCBMsgArgData": d.value,
+				"kCBMsgArgData": v,
 				"kCBMsgArgUUID": reverse(d.uuid.b),
 			}
 			xds = append(xds, xd)

--- a/examples/service/battery.go
+++ b/examples/service/battery.go
@@ -12,9 +12,8 @@ func NewBatteryService() *gatt.Service {
 			lv--
 		})
 
-	// FIXME: this cause connection interrupted on Mac.
 	// Characteristic User Description
-	// c.AddDescriptor(gatt.UUID16(0x2901)).SetValue([]byte("Battery level between 0 and 100 percent"))
+	c.AddDescriptor(gatt.UUID16(0x2901)).SetStringValue("Battery level between 0 and 100 percent")
 
 	// Characteristic Presentation Format
 	c.AddDescriptor(gatt.UUID16(0x2904)).SetValue([]byte{4, 1, 39, 173, 1, 0, 0})


### PR DESCRIPTION
These need to be passed to XPC as strings, not []byte slices.
This is necessary for descriptors such as the user description (0x2901).