### PR TITLE
Add PoweredDown callback for Mac when Stop() is called

### DIFF
--- a/device_darwin.go
+++ b/device_darwin.go
@@ -144,6 +144,7 @@ func (d *device) StopAdvertising() error {
 
 func (d *device) Stop() error {
 	// No Implementation
+	defer d.stateChanged(d, StatePoweredOff)
 	return errors.New("FIXME: Advertise error")
 }
 


### PR DESCRIPTION
For parity with the Linux implementation.